### PR TITLE
Add gh link to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,3 +31,4 @@ VignetteBuilder: knitr
 RoxygenNote: 7.1.2
 Language: en-US
 URL: https://f8l5h9.github.io/spqdep/
+BugReports: https://github.com/f8l5h9/spqdep/issues


### PR DESCRIPTION
Enables discovering repo more easily as well as adding links in the pkgdown website to repo. https://blog.r-hub.io/2019/12/10/urls/